### PR TITLE
Use atomic-polyfill instead of std AtomicBool

### DIFF
--- a/cortex-m-interrupt-macro/src/take.rs
+++ b/cortex-m-interrupt-macro/src/take.rs
@@ -31,7 +31,7 @@ impl Take {
             {
                 struct Handle;
 
-                static REGISTERED: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+                static REGISTERED: ::cortex_m_interrupt::atomic_polyfill::AtomicBool = ::cortex_m_interrupt::atomic_polyfill::AtomicBool::new(false);
 
                 static mut HANDLER: fn() = || { unsafe { ::cortex_m_interrupt::DefaultHandler_()  } };
 

--- a/cortex-m-interrupt/Cargo.toml
+++ b/cortex-m-interrupt/Cargo.toml
@@ -15,6 +15,7 @@ license = "MIT OR Apache-2.0"
 cortex-m-interrupt-macro = { path = "../cortex-m-interrupt-macro" }
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
+atomic-polyfill = "1.0.1"
 
 [dev-dependencies]
 stm32f1xx-hal = { version = "0.9", features = [ "stm32f107" ] }

--- a/cortex-m-interrupt/src/lib.rs
+++ b/cortex-m-interrupt/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(not(test), no_std)]
 
 // Re-exports
+pub use atomic_polyfill;
 pub use cortex_m;
 pub use cortex_m_rt::DefaultHandler_;
 


### PR DESCRIPTION
Use `atomic-polyfill`'s `AtomicBool` instead of `std::sync::atomic::AtomicBool`. This enables use for targets which don't have native atomics (ie, Cortex-M0+).